### PR TITLE
`Forcing leagueID to 1 for draft night

### DIFF
--- a/components/modals/CardLightBoxModal.tsx
+++ b/components/modals/CardLightBoxModal.tsx
@@ -270,7 +270,7 @@ const CardLightBoxModal = ({
               playerID={playerID}
               cardID={cardID}
               userID={userID}
-              leagueID={leagueID}
+              leagueID={rarity === 'Draft Night' ? 1 : leagueID}
             />
           </DrawerBody>
         </DrawerContent>


### PR DESCRIPTION
Draft night card people want the leagueID to be 1 for the player stats but keep it as leagueID of 0 for everything else for the filters