### PR TITLE
Feat/upgraded admin cards

### DIFF
--- a/components/common/CardInfo.tsx
+++ b/components/common/CardInfo.tsx
@@ -14,7 +14,7 @@ export const generateCardTooltipContent = (
 
   const portalGenInfo = portalPlayer
     ? `Jersey Num: ${portalPlayer.jerseyNumber}\n    Render: ${portalPlayer.render}`
-    : `no portal info found`
+    : `No Jersey Found | ${card.render_name}`
   const award_rarity =
     card.card_rarity === 'Awards'
       ? `Awards - ${card.sub_type}`
@@ -23,7 +23,8 @@ export const generateCardTooltipContent = (
   const basicInfo = `
     ${card.player_name}
     ${portalGenInfo}
-    Rarity: ${award_rarity} | Pos: ${card.position}
+    Rarity: ${award_rarity} 
+    Pos: ${card.position}
     Season: ${card.season} | Overall: ${card.overall}
     Team: ${teamInfo.name} (${teamInfo.abbreviation})
       `.trim()

--- a/components/common/CardInfo.tsx
+++ b/components/common/CardInfo.tsx
@@ -1,21 +1,32 @@
 import React, { useState } from 'react'
 import { Button } from '@chakra-ui/react'
 import { indexAxios, query } from '@pages/api/database/query'
-import { Team } from '@pages/api/v3'
+import { PortalInfo, Team } from '@pages/api/v3'
+import axios from 'axios'
 
-export const generateCardTooltipContent = (card: Card, teamData: Team[]) => {
+export const generateCardTooltipContent = (
+  card: Card,
+  teamData: Team[],
+  portalInfo: PortalInfo
+) => {
   const teamInfo = teamData.find((t) => t.id === card.teamID)
+  const portalPlayer = portalInfo?.[0]
+
+  const portalGenInfo = portalPlayer
+    ? `Jersey Num: ${portalPlayer.jerseyNumber}\n    Render: ${portalPlayer.render}`
+    : `no portal info found`
   const award_rarity =
     card.card_rarity === 'Awards'
       ? `Awards - ${card.sub_type}`
       : card.card_rarity
 
   const basicInfo = `
-${card.player_name}
-Rarity: ${award_rarity} | Pos: ${card.position}
-Season: ${card.season} | Overall: ${card.overall}
-Team: ${teamInfo.name} (${teamInfo.abbreviation})
-  `.trim()
+    ${card.player_name}
+    ${portalGenInfo}
+    Rarity: ${award_rarity} | Pos: ${card.position}
+    Season: ${card.season} | Overall: ${card.overall}
+    Team: ${teamInfo.name} (${teamInfo.abbreviation})
+      `.trim()
 
   let positionSkills = ``
 
@@ -40,6 +51,16 @@ export const CardInfo = ({ card }: { card: Card }) => {
       }),
   })
 
+  const { payload: portalInfo, isLoading: portalInfoIsLoading } =
+    query<PortalInfo>({
+      queryKey: ['portalInfo', String(card.leagueID), String(card.playerID)],
+      queryFn: () =>
+        axios({
+          method: 'GET',
+          url: `/api/v3/cards/portalInfo?leagueID=${card.leagueID}&playerID=${card.playerID}`,
+        }),
+    })
+
   return (
     <div className="pt-2">
       <Button
@@ -48,9 +69,9 @@ export const CardInfo = ({ card }: { card: Card }) => {
       >
         Show Card Info
       </Button>
-      {isVisible && !teamDataIsLoading && (
+      {isVisible && !teamDataIsLoading && !portalInfoIsLoading && (
         <pre className="whitespace-pre-wrap break-words font-mono mt-2 sm:mt-4 lg:mt-6">
-          {generateCardTooltipContent(card, teamData)}
+          {generateCardTooltipContent(card, teamData, portalInfo)}
         </pre>
       )}
     </div>

--- a/pages/admin/cards.tsx
+++ b/pages/admin/cards.tsx
@@ -2,7 +2,6 @@ import { ChevronDownIcon } from '@chakra-ui/icons'
 import {
   Button,
   FormControl,
-  FormLabel,
   Input,
   Menu,
   MenuButton,
@@ -10,13 +9,15 @@ import {
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
-  Switch,
   Table,
   TableContainer,
   Tbody,
   Th,
   Thead,
   Tr,
+  Tabs,
+  TabList,
+  Tab,
   useDisclosure,
   Image,
   ModalOverlay,
@@ -40,8 +41,8 @@ import { GET } from '@constants/http-methods'
 import { useRedirectIfNotAuthenticated } from '@hooks/useRedirectIfNotAuthenticated'
 import { useRedirectIfNotAuthorized } from '@hooks/useRedirectIfNotAuthorized'
 import { query, indexAxios } from '@pages/api/database/query'
-import { ListResponse, SortDirection } from '@pages/api/v3'
-import axios from 'axios'
+import { ListResponse, seasoninfo, SortDirection } from '@pages/api/v3'
+import axios, { AxiosResponse } from 'axios'
 import { useState } from 'react'
 import { cardService } from 'services/cardService'
 import { useCookie } from '@hooks/useCookie'
@@ -58,6 +59,8 @@ import RadioGroupSelector from '@components/common/RadioGroupSelector'
 import { LEAGUE_OPTIONS } from 'lib/constants'
 
 type ColumnName = keyof Readonly<Card>
+
+type CardTab = 'skaters' | 'goaltenders' | 'my-cards'
 
 const ROWS_PER_PAGE: number = 10 as const
 
@@ -94,9 +97,18 @@ const LOADING_TABLE_DATA: { rows: Card[] } = {
   })),
 } as const
 
+const TAB_CONFIG: { key: CardTab; label: string }[] = [
+  { key: 'skaters', label: 'Skaters' },
+  { key: 'goaltenders', label: 'Goaltenders' },
+  { key: 'my-cards', label: 'My Claimed Cards' },
+]
+
 export default () => {
-  const [viewSkaters, setViewSkaters] = useState<boolean>(true)
-  const [viewMyCards, setViewMyCards] = useState<boolean>(false)
+  const [activeTab, setActiveTab] = useState<CardTab>('skaters')
+
+  const viewSkaters = activeTab !== 'goaltenders'
+  const viewMyCards = activeTab === 'my-cards'
+
   const [viewNeedsAuthor, setViewNeedsAuthor] = useState<boolean>(false)
   const [viewNeedsImage, setviewNeedsImage] = useState<boolean>(false)
   const [viewNeedsApproval, setviewNeedsApproval] = useState<boolean>(false)
@@ -116,6 +128,7 @@ export default () => {
   const [selectedCard, setSelectedCard] = useState<Card>(null)
   const [imageUrl, setImageUrl] = useState<string>(null)
   const [cardID, setCardID] = useState<string>(null)
+  const [seasons, setSeasons] = useState<string[]>([])
 
   const claimCardDialog = useDisclosure()
   const updateModal = useDisclosure()
@@ -137,6 +150,11 @@ export default () => {
   const clearAllFilters = () => {
     setTeams([])
     setRarities([])
+  }
+
+  const handleTabChange = (index: number) => {
+    setActiveTab(TAB_CONFIG[index].key)
+    setTablePage(1)
   }
 
   const { payload: teamData, isLoading: teamDataIsLoading } = query<Team[]>({
@@ -164,6 +182,18 @@ export default () => {
       setImageUrl(image_url)
     }
   }
+
+  const { payload: draftSeasons, isLoading: draftSeasonsIsLoading } = query<
+    seasoninfo[]
+  >({
+    queryKey: ['draftSeasons'],
+    queryFn: () =>
+      axios({
+        method: GET,
+        url: `https://index.simulationhockey.com/api/v1/leagues/seasons?league=0`,
+      }),
+  })
+
   const { payload, isLoading } = query<ListResponse<Card>>({
     queryKey: [
       'cards',
@@ -184,6 +214,7 @@ export default () => {
       cardID,
       JSON.stringify(leagueID),
       JSON.stringify(teamLeagueID),
+      JSON.stringify(seasons),
     ],
     queryFn: () =>
       axios({
@@ -208,6 +239,7 @@ export default () => {
           cardID: cardID,
           leagueID: JSON.stringify(leagueID),
           teamLeagueID: JSON.stringify(teamLeagueID),
+          draftSeason: JSON.stringify(seasons),
         },
       }),
   })
@@ -252,15 +284,28 @@ export default () => {
         className="h-full flex flex-col justify-center items-center w-11/12 md:w-3/4"
       >
         <p>Card Management</p>
+        <Tabs
+          onChange={handleTabChange}
+          index={TAB_CONFIG.findIndex((t) => t.key === activeTab)}
+          isFitted
+          variant="enclosed-colored"
+          isLazy
+        >
+          <TabList>
+            {TAB_CONFIG.map((tab) => (
+              <Tab
+                _selected={{
+                  borderBottomColor: 'blue.600',
+                }}
+                className="!bg-primary !text-secondary !border-b-4"
+                key={tab.key}
+              >
+                {tab.label}
+              </Tab>
+            ))}
+          </TabList>
+        </Tabs>
         <div className="rounded border border-1 border-inherit mt-4">
-          <FormControl>
-            <Input
-              className="w-full bg-secondary border-grey100"
-              placeholder="Search By Player Name or Card ID"
-              size="lg"
-              onChange={(event) => setPlayerOrCardID(event.target.value)}
-            />
-          </FormControl>
           <div className="m-2 flex flex-col gap-4 md:flex-row md:justify-between">
             <RadioGroupSelector
               value={leagueID}
@@ -275,34 +320,32 @@ export default () => {
 
           <div className="m-2 flex flex-col gap-4 md:flex-row md:justify-between">
             <div className="flex flex-col gap-4 md:flex-row md:space-x-2 w-full md:w-auto">
-              <div className="flex flex-col gap-4 md:flex-row md:space-x-2 w-full md:w-auto">
-                <FilterDropdown
-                  label="Teams"
-                  selectedValues={teams}
-                  options={teamData || []}
-                  isLoading={teamDataIsLoading}
-                  onToggle={toggleTeam}
-                  onDeselectAll={() => {
-                    setTeams([])
-                    setTeamLeagueID({})
-                  }}
-                  getOptionId={(team) => `${team.league}-${team.id}`}
-                  getOptionValue={(team) => `${team.league}-${team.id}`}
-                  getOptionLabel={(team) => team.name}
-                />
+              <FilterDropdown
+                label="Teams"
+                selectedValues={teams}
+                options={teamData || []}
+                isLoading={teamDataIsLoading}
+                onToggle={toggleTeam}
+                onDeselectAll={() => {
+                  setTeams([])
+                  setTeamLeagueID({})
+                }}
+                getOptionId={(team) => `${team.league}-${team.id}`}
+                getOptionValue={(team) => `${team.league}-${team.id}`}
+                getOptionLabel={(team) => team.name}
+              />
 
-                <FilterDropdown<Rarities>
-                  label="Rarities"
-                  selectedValues={rarities}
-                  options={rarityData || []}
-                  isLoading={rarityDataisLoading}
-                  onToggle={toggleRarity}
-                  onDeselectAll={() => setRarities([])}
-                  getOptionId={(rarity) => rarity.card_rarity}
-                  getOptionValue={(rarity) => rarity.card_rarity}
-                  getOptionLabel={(rarity) => rarity.card_rarity}
-                />
-              </div>
+              <FilterDropdown<Rarities>
+                label="Rarities"
+                selectedValues={rarities}
+                options={rarityData || []}
+                isLoading={rarityDataisLoading}
+                onToggle={toggleRarity}
+                onDeselectAll={() => setRarities([])}
+                getOptionId={(rarity) => rarity.card_rarity}
+                getOptionValue={(rarity) => rarity.card_rarity}
+                getOptionLabel={(rarity) => rarity.card_rarity}
+              />
 
               <FormControl>
                 <Menu closeOnSelect={false}>
@@ -352,18 +395,61 @@ export default () => {
                   </MenuList>
                 </Menu>
               </FormControl>
-            </div>
-            <div className="flex justify-end">
-              <FormControl className="flex items-center m-2">
-                <FormLabel className="mb-0">My Cards</FormLabel>
-                <Switch onChange={() => setViewMyCards(!viewMyCards)} />
-              </FormControl>
-              <FormControl className="flex items-center m-2">
-                <FormLabel className="mb-0">Toggle Goaltenders:</FormLabel>
-                <Switch onChange={() => setViewSkaters(!viewSkaters)} />
+              <FormControl>
+                <Menu>
+                  <MenuButton
+                    as={Button}
+                    rightIcon={<ChevronDownIcon />}
+                    className="text-primary"
+                  >
+                    Draft Season
+                  </MenuButton>
+
+                  <MenuList>
+                    <span className="text-primary">
+                      <MenuOptionGroup
+                        type="checkbox"
+                        value={seasons}
+                        onChange={(value) =>
+                          setSeasons(Array.isArray(value) ? value : [value])
+                        }
+                      >
+                        <MenuItemOption
+                          key="all"
+                          value="all"
+                          className="hover:bg-highlighted/40"
+                        >
+                          All
+                        </MenuItemOption>
+                        {(draftSeasons ?? [])
+                          .slice()
+                          .reverse()
+                          .map((season) => (
+                            <MenuItemOption
+                              key={season.season}
+                              value={String(season.season)}
+                              className="hover:bg-highlighted/40"
+                            >
+                              S{season.season}
+                            </MenuItemOption>
+                          ))}
+                      </MenuOptionGroup>
+                    </span>
+                  </MenuList>
+                </Menu>
               </FormControl>
             </div>
           </div>
+
+          <FormControl className="m-2 mt-4 !w-4/5">
+            <Input
+              className="w-full bg-secondary border-grey100"
+              placeholder="Search By Player Name or Card ID"
+              size="lg"
+              onChange={(event) => setPlayerOrCardID(event.target.value)}
+            />
+          </FormControl>
+
           <TableContainer>
             <Table variant="cardtable" className="mt-4" size="md">
               <Thead>

--- a/pages/admin/cards.tsx
+++ b/pages/admin/cards.tsx
@@ -41,9 +41,9 @@ import { GET } from '@constants/http-methods'
 import { useRedirectIfNotAuthenticated } from '@hooks/useRedirectIfNotAuthenticated'
 import { useRedirectIfNotAuthorized } from '@hooks/useRedirectIfNotAuthorized'
 import { query, indexAxios } from '@pages/api/database/query'
-import { ListResponse, seasoninfo, SortDirection } from '@pages/api/v3'
+import { ListResponse, seasoninfo, SortDirection, SubType } from '@pages/api/v3'
 import axios, { AxiosResponse } from 'axios'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { cardService } from 'services/cardService'
 import { useCookie } from '@hooks/useCookie'
 import config from 'lib/config'
@@ -57,6 +57,9 @@ import { Team, Rarities } from '@pages/api/v3'
 import FilterDropdown from '@components/common/FilterDropdown'
 import RadioGroupSelector from '@components/common/RadioGroupSelector'
 import { LEAGUE_OPTIONS } from 'lib/constants'
+import Link from 'next/link'
+import { CardInfo } from '@components/common/CardInfo'
+import { useDebounce } from 'use-debounce'
 
 type ColumnName = keyof Readonly<Card>
 
@@ -116,20 +119,28 @@ export default () => {
   const [viewDone, setViewDone] = useState<boolean>(false)
 
   const [playerName, setPlayerName] = useState<string>(null)
+  const [authorName, setAuthorName] = useState<string>(null)
+  const [cardID, setCardID] = useState<string>(null)
+  const [debouncedPlayerName] = useDebounce(playerName, 500)
+  const [debouncedCardID] = useDebounce(cardID, 500)
+  const [debouncedAuthorName] = useDebounce(authorName, 500)
+
   const [teams, setTeams] = useState<string[]>([])
+  const [subType, setSubType] = useState<string[]>([])
+  const [rarities, setRarities] = useState<string[]>([])
+
   const [teamLeagueID, setTeamLeagueID] = useState<{ [key: string]: string }>(
     {}
   )
-  const [rarities, setRarities] = useState<string[]>([])
   const [leagueID, setLeagueID] = useState<string[]>(['0'])
   const [sortColumn, setSortColumn] = useState<ColumnName>('player_name')
   const [sortDirection, setSortDirection] = useState<SortDirection>('ASC')
   const [tablePage, setTablePage] = useState<number>(1)
   const [selectedCard, setSelectedCard] = useState<Card>(null)
   const [imageUrl, setImageUrl] = useState<string>(null)
-  const [cardID, setCardID] = useState<string>(null)
   const [seasons, setSeasons] = useState<string[]>([])
 
+  const viewCardInfo = useDisclosure()
   const claimCardDialog = useDisclosure()
   const updateModal = useDisclosure()
   const removeAuthorDialog = useDisclosure()
@@ -177,6 +188,19 @@ export default () => {
       }),
   })
 
+  const { payload: subTypeData, isLoading: subTypeDataIsLoading } = query<
+    SubType[]
+  >({
+    queryKey: ['subTypeData', leagueID.join(','), JSON.stringify(rarities)],
+    queryFn: () =>
+      axios({
+        method: GET,
+        url: `/api/v3/cards/sub-rarity-map?leagueID=${leagueID}&rarities=${JSON.stringify(
+          rarities
+        )}`,
+      }),
+  })
+
   const showImage = (image_url: string) => () => {
     if (image_url) {
       setImageUrl(image_url)
@@ -198,9 +222,10 @@ export default () => {
     queryKey: [
       'cards',
       uid,
-      playerName,
+      debouncedPlayerName,
       JSON.stringify(teams),
       JSON.stringify(rarities),
+      JSON.stringify(subType),
       String(viewSkaters),
       String(viewMyCards),
       String(viewNeedsAuthor),
@@ -211,10 +236,11 @@ export default () => {
       sortColumn,
       sortDirection,
       String(tablePage),
-      cardID,
+      debouncedCardID,
       JSON.stringify(leagueID),
       JSON.stringify(teamLeagueID),
       JSON.stringify(seasons),
+      debouncedAuthorName,
     ],
     queryFn: () =>
       axios({
@@ -224,9 +250,10 @@ export default () => {
           limit: ROWS_PER_PAGE,
           offset: Math.max((tablePage - 1) * ROWS_PER_PAGE, 0),
           userID: uid,
-          playerName,
+          playerName: debouncedPlayerName,
           teams: JSON.stringify(teams),
           rarities: JSON.stringify(rarities),
+          subType: JSON.stringify(subType),
           viewSkaters,
           viewMyCards,
           viewNeedsAuthor,
@@ -236,10 +263,11 @@ export default () => {
           viewDone,
           sortColumn,
           sortDirection,
-          cardID: cardID,
+          cardID: debouncedCardID,
           leagueID: JSON.stringify(leagueID),
           teamLeagueID: JSON.stringify(teamLeagueID),
           draftSeason: JSON.stringify(seasons),
+          author_name: debouncedAuthorName,
         },
       }),
   })
@@ -261,21 +289,33 @@ export default () => {
     setRarities((currentValue) => toggleOnfilters(currentValue, rarity))
   }
 
-  const setPlayerOrCardID = (value: string) => {
-    if (/^\d+$/.test(value)) {
-      // if the value is only a number
-      setCardID(value)
-      setPlayerName(null)
-    } else {
-      if (value.length > 0) {
-        setPlayerName(value)
-        setCardID(null)
-      } else {
-        setPlayerName(null)
-        setCardID(null)
-      }
-    }
+  const toggleSubType = (subType: string) => {
+    setSubType((currentValue) => toggleOnfilters(currentValue, subType))
   }
+
+  const parseSearchQuery = (raw: string) => {
+    const tagPattern = /(\w+):("([^"]+)"|(\S+))/g
+    let remaining = raw
+    const extracted: Record<string, string> = {}
+
+    let match: RegExpExecArray | null
+    while ((match = tagPattern.exec(raw)) !== null) {
+      extracted[match[1].toLowerCase()] = match[3] ?? match[4]
+      remaining = remaining.replace(match[0], '').trim()
+    }
+
+    setPlayerName(
+      extracted['name'] ?? (remaining.length > 0 ? remaining : null)
+    )
+    setCardID(extracted['id'] ?? null)
+    setAuthorName(extracted['author'] ?? null)
+  }
+
+  useEffect(() => {
+    if (subTypeData && subTypeData.length === 0 && subType.length > 0) {
+      setSubType([])
+    }
+  }, [subTypeData])
 
   return (
     <>
@@ -347,6 +387,18 @@ export default () => {
                 getOptionLabel={(rarity) => rarity.card_rarity}
               />
 
+              <FilterDropdown<SubType>
+                label="Sub Types"
+                selectedValues={subType}
+                options={subTypeData || []}
+                isLoading={subTypeDataIsLoading}
+                onToggle={toggleSubType}
+                onDeselectAll={() => setSubType([])}
+                getOptionId={(subType) => subType.sub_type}
+                getOptionValue={(subType) => subType.sub_type}
+                getOptionLabel={(subType) => subType.sub_type}
+              />
+
               <FormControl>
                 <Menu closeOnSelect={false}>
                   <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
@@ -396,7 +448,7 @@ export default () => {
                 </Menu>
               </FormControl>
               <FormControl>
-                <Menu>
+                <Menu closeOnSelect={false}>
                   <MenuButton
                     as={Button}
                     rightIcon={<ChevronDownIcon />}
@@ -446,8 +498,14 @@ export default () => {
               className="w-full bg-secondary border-grey100"
               placeholder="Search By Player Name or Card ID"
               size="lg"
-              onChange={(event) => setPlayerOrCardID(event.target.value)}
+              onChange={(event) => parseSearchQuery(event.target.value)}
             />
+            <p className="mt-1 text-xs text-gray-400">
+              Search by player name, or use tags:{' '}
+              <span className="font-mono">name:Andrei</span>{' '}
+              <span className="font-mono">author:Enigmatic</span>{' '}
+              <span className="font-mono">id:2528</span>
+            </p>
           </FormControl>
 
           <TableContainer>
@@ -470,16 +528,8 @@ export default () => {
                       )}
                     </span>
                   </Th>
-                  <Th
-                    className="cursor-pointer"
-                    onClick={() => handleSortChange('render_name')}
-                  >
-                    <span className="flex items-center">
-                      Render&nbsp;
-                      {sortColumn === 'render_name' && (
-                        <SortIcon sortDirection={sortDirection} />
-                      )}
-                    </span>
+                  <Th className="cursor-pointer">
+                    <span className="flex items-center">Card Info&nbsp;</span>
                   </Th>
                   <Th
                     className="cursor-pointer"
@@ -505,10 +555,21 @@ export default () => {
                   </Th>
                   <Th
                     className="cursor-pointer"
+                    onClick={() => handleSortChange('render_name')}
+                  >
+                    <span className="flex items-center">
+                      Render&nbsp;
+                      {sortColumn === 'render_name' && (
+                        <SortIcon sortDirection={sortDirection} />
+                      )}
+                    </span>
+                  </Th>
+                  <Th
+                    className="cursor-pointer"
                     onClick={() => handleSortChange('teamID')}
                   >
                     <span className="flex items-center">
-                      Team ID&nbsp;
+                      Team&nbsp;
                       {sortColumn === 'teamID' && (
                         <SortIcon sortDirection={sortDirection} />
                       )}
@@ -827,10 +888,40 @@ export default () => {
                           {cardService.calculateStatus(card)}
                         </Td>
                         <Td isLoading={isLoading}>{card.player_name}</Td>
-                        <Td isLoading={isLoading}>{card.render_name}</Td>
+                        <Td isLoading={isLoading}>
+                          <Button
+                            size="sm"
+                            onClick={() => {
+                              setSelectedCard(card)
+                              viewCardInfo.onOpen()
+                            }}
+                          >
+                            Show Info
+                          </Button>
+                        </Td>
                         <Td isLoading={isLoading}>{card.cardID}</Td>
-                        <Td isLoading={isLoading}>{card.playerID}</Td>
-                        <Td isLoading={isLoading}>{card.teamID}</Td>
+                        <Td isLoading={isLoading}>
+                          <Link
+                            href={`https://index.simulationhockey.com/${LEAGUE_OPTIONS.find(
+                              (l) => l.value === String(card.leagueID)
+                            ).label.toLowerCase()}/player/${card.playerID}`}
+                            className="!hover:no-underline ml-2 block pb-2 text-left text-link"
+                            target="_blank"
+                          >
+                            {' '}
+                            {card.playerID}
+                          </Link>
+                        </Td>
+                        <Td isLoading={isLoading}>{card.render_name}</Td>
+                        <Td isLoading={isLoading}>
+                          {
+                            teamData?.find(
+                              (t) =>
+                                t.id === card.teamID &&
+                                t.league === card.leagueID
+                            )?.name
+                          }
+                        </Td>
                         <Td isLoading={isLoading}>{card.author_username}</Td>
                         <Td isLoading={isLoading}>{card.pullable}</Td>
                         <Td isLoading={isLoading}>{card.approved}</Td>
@@ -875,6 +966,27 @@ export default () => {
           />
         </div>
       </PageWrapper>
+
+      {selectedCard && viewCardInfo.isOpen && (
+        <Modal
+          isOpen={viewCardInfo.isOpen}
+          onClose={() => {
+            viewCardInfo.onClose()
+            setSelectedCard(null)
+          }}
+        >
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader className="bg-primary text-secondary">
+              Card Info
+            </ModalHeader>
+            <ModalCloseButton />
+            <ModalBody className="bg-primary text-secondary">
+              <CardInfo card={selectedCard} />
+            </ModalBody>
+          </ModalContent>
+        </Modal>
+      )}
       {selectedCard && (
         <>
           <ClaimCardDialog

--- a/pages/api/v3/cards/index.ts
+++ b/pages/api/v3/cards/index.ts
@@ -58,6 +58,7 @@ export default async function cardsEndpoint(
     ].some((viewStatus) => viewStatus === 'true')
 
     const cardID = req.query.cardID as string
+    const author_name = req.query.author_name as string
     const date_approved = req.query.date_approved as string
 
     const query: SQLStatement = SQL`
@@ -165,6 +166,10 @@ export default async function cardsEndpoint(
       query.append(SQL` AND player_name LIKE ${`%${playerName}%`}`)
     }
 
+    if (author_name) {
+      query.append(SQL` AND user_info.username LIKE ${`%${author_name}%`}`)
+    }
+
     if (teams.length !== 0) {
       query.append(SQL` AND (`)
       teams.forEach((team, index) => {
@@ -233,7 +238,8 @@ export default async function cardsEndpoint(
     if (sortColumn === 'conditioning') query.append(SQL` conditioning`)
     if (sortColumn === 'card_rarity') query.append(SQL` card_rarity`)
     if (sortColumn === 'date_approved') query.append(SQL` date_approved`)
-    if (sortColumn === 'render_name') query.append(SQL` render_name`)
+    if (sortColumn === 'render_name')
+      query.append(SQL` (render_name = '' OR render_name IS NULL), render_name`)
     sortDirection === 'ASC' ? query.append(SQL` ASC`) : query.append(` DESC`)
 
     if (limit) {

--- a/pages/api/v3/cards/index.ts
+++ b/pages/api/v3/cards/index.ts
@@ -47,6 +47,7 @@ export default async function cardsEndpoint(
     const leagues = parseQueryArray(req.query.leagueID)
     const teams = parseQueryArray(req.query.teams)
     const rarities = parseQueryArray(req.query.rarities)
+    const draftSeason = parseQueryArray(req.query.draftSeason)
 
     const hasSortStatus: boolean = [
       viewNeedsAuthor,
@@ -182,6 +183,20 @@ export default async function cardsEndpoint(
           )
         }
       })
+      query.append(SQL`)`)
+    }
+
+    if (draftSeason.length !== 0) {
+      query.append(SQL` AND season IN (`)
+
+      draftSeason.forEach((season, index) => {
+        if (index === 0) {
+          query.append(SQL`${parseInt(season)}`)
+        } else {
+          query.append(SQL`, ${parseInt(season)}`)
+        }
+      })
+
       query.append(SQL`)`)
     }
 

--- a/pages/api/v3/cards/portalInfo.ts
+++ b/pages/api/v3/cards/portalInfo.ts
@@ -23,8 +23,6 @@ export default async function cardInfo(
     const playerID = req.query.playerID as string
     const leagueID = req.query.leagueID as string
 
-    console.log(playerID)
-
     if (!playerID || !leagueID || playerID === '1') {
       res.status(StatusCodes.BAD_REQUEST).json({
         status: 'error',

--- a/pages/api/v3/cards/portalInfo.ts
+++ b/pages/api/v3/cards/portalInfo.ts
@@ -1,0 +1,55 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { GET } from '@constants/http-methods'
+import { StatusCodes } from 'http-status-codes'
+import middleware from '@pages/api/database/middleware'
+import Cors from 'cors'
+import SQL from 'sql-template-strings'
+import { ApiResponse, PortalInfo } from '..'
+import methodNotAllowed from '../lib/methodNotAllowed'
+import { cardsQuery } from '@pages/api/database/database'
+
+const allowedMethods = [GET]
+const cors = Cors({
+  methods: allowedMethods,
+})
+
+export default async function cardInfo(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse<PortalInfo[]>>
+): Promise<void> {
+  await middleware(req, res, cors)
+
+  if (req.method === GET) {
+    const playerID = req.query.playerID as string
+    const leagueID = req.query.leagueID as string
+
+    console.log(playerID)
+
+    if (!playerID || !leagueID || playerID === '1') {
+      res.status(StatusCodes.BAD_REQUEST).json({
+        status: 'error',
+        message: 'Please provide a cardID or leagueID in your request',
+      })
+      return
+    }
+
+    const queryResult = await cardsQuery(SQL`
+     CALL get_card_maker_info(${leagueID}, ${playerID})
+    `)
+
+    if ('error' in queryResult) {
+      console.error(queryResult)
+      res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .end('Server connection failed')
+      return
+    }
+
+    res
+      .status(StatusCodes.OK)
+      .json({ status: 'success', payload: queryResult[0] as PortalInfo[] })
+    return
+  }
+
+  methodNotAllowed(req, res, allowedMethods)
+}

--- a/pages/api/v3/index.d.ts
+++ b/pages/api/v3/index.d.ts
@@ -131,4 +131,16 @@ export type Team = {
   colors: { primary: string; secondary: string; text: string }
 }
 
+export type PortalInfo = {
+  jerseyNumber: number
+  render: string
+}
+
+export type seasoninfo = {
+  id: number
+  name: string
+  abbreviation: string
+  season: number
+}
+
 export type SortDirection = 'ASC' | 'DESC'


### PR DESCRIPTION
- new api route called portalInfo.ts Uses a proc to grab jersey number and render from the portal. and display it when the user clicks show info on any card. If their playerID is tied back to a portal player, will display their jersey and render
- Added a new draft season filter in the admin cards area. Allows the user to multi select draft seasons to help them pick and choose what cards to make
- Moved goaltenders and your claimed cards to tabs instead of switches
- Utilized the index api for seasons for the draft season selector
- Added sub rarity filter in the admin card site area as well. 
- Modified existing player/ cardID search to include author ID as well as using tags for search. Added debouncing to the fields so that the database doesnt get called everytime a letter is pressed
- With us having teamName from the teams api, we are able to include team name instead of teamID. especially since we only have 10 cards per. The sorting is broken but they can use the filters for getting a specific team
- For rarity asc or desc, modified the existing sql to allow the asc to include the renders first instead of "" blanks