### PR TITLE
3 fixes

### DIFF
--- a/components/common/CardInfo.tsx
+++ b/components/common/CardInfo.tsx
@@ -43,6 +43,8 @@ export const generateCardTooltipContent = (
 export const CardInfo = ({ card }: { card: Card }) => {
   const [isVisible, setIsVisible] = useState(true)
 
+  const leagueID = card.card_rarity === 'Draft Night' ? 1 : card.leagueID
+
   const { payload: teamData, isLoading: teamDataIsLoading } = query<Team[]>({
     queryKey: ['teamData', String(card.leagueID)],
     queryFn: () =>
@@ -54,11 +56,11 @@ export const CardInfo = ({ card }: { card: Card }) => {
 
   const { payload: portalInfo, isLoading: portalInfoIsLoading } =
     query<PortalInfo>({
-      queryKey: ['portalInfo', String(card.leagueID), String(card.playerID)],
+      queryKey: ['portalInfo', String(leagueID), String(card.playerID)],
       queryFn: () =>
         axios({
           method: 'GET',
-          url: `/api/v3/cards/portalInfo?leagueID=${card.leagueID}&playerID=${card.playerID}`,
+          url: `/api/v3/cards/portalInfo?leagueID=${leagueID}&playerID=${card.playerID}`,
         }),
     })
 

--- a/pages/admin/cards.tsx
+++ b/pages/admin/cards.tsx
@@ -26,6 +26,7 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalHeader,
+  ButtonGroup,
 } from '@chakra-ui/react'
 import DeleteCardDialog from '@components/admin-cards/DeleteCardDialog'
 import RemoveCardAuthorDialog from '@components/admin-cards/RemoveCardAuthorDialog'
@@ -63,7 +64,7 @@ import { useDebounce } from 'use-debounce'
 
 type ColumnName = keyof Readonly<Card>
 
-type CardTab = 'skaters' | 'goaltenders' | 'my-cards'
+type CardTab = 'cards' | 'my-cards'
 
 const ROWS_PER_PAGE: number = 10 as const
 
@@ -101,22 +102,20 @@ const LOADING_TABLE_DATA: { rows: Card[] } = {
 } as const
 
 const TAB_CONFIG: { key: CardTab; label: string }[] = [
-  { key: 'skaters', label: 'Skaters' },
-  { key: 'goaltenders', label: 'Goaltenders' },
+  { key: 'cards', label: 'Cards' },
   { key: 'my-cards', label: 'My Claimed Cards' },
 ]
 
 export default () => {
-  const [activeTab, setActiveTab] = useState<CardTab>('skaters')
-
-  const viewSkaters = activeTab !== 'goaltenders'
-  const viewMyCards = activeTab === 'my-cards'
-
+  const [activeTab, setActiveTab] = useState<CardTab>('cards')
   const [viewNeedsAuthor, setViewNeedsAuthor] = useState<boolean>(false)
   const [viewNeedsImage, setviewNeedsImage] = useState<boolean>(false)
   const [viewNeedsApproval, setviewNeedsApproval] = useState<boolean>(false)
   const [viewNeedsAuthorPaid, setviewNeedsAuthorPaid] = useState<boolean>(false)
   const [viewDone, setViewDone] = useState<boolean>(false)
+  const [playerType, setPlayerType] = useState<'skaters' | 'goaltenders'>(
+    'skaters'
+  )
 
   const [playerName, setPlayerName] = useState<string>(null)
   const [authorName, setAuthorName] = useState<string>(null)
@@ -157,6 +156,9 @@ export default () => {
   const { isCheckingAuthorization } = useRedirectIfNotAuthorized({
     roles: ['TRADING_CARD_ADMIN', 'TRADING_CARD_TEAM'],
   })
+
+  const viewSkaters = playerType !== 'goaltenders'
+  const viewMyCards = activeTab === 'my-cards'
 
   const clearAllFilters = () => {
     setTeams([])
@@ -356,6 +358,26 @@ export default () => {
                 clearAllFilters()
               }}
             />
+            <ButtonGroup size="md" className="mt-2">
+              <Button
+                borderRadius="full"
+                px={4}
+                variant={playerType === 'skaters' ? 'solid' : 'outline'}
+                colorScheme="blue"
+                onClick={() => setPlayerType('skaters')}
+              >
+                Skaters
+              </Button>
+              <Button
+                borderRadius="full"
+                px={4}
+                variant={playerType === 'goaltenders' ? 'solid' : 'outline'}
+                colorScheme="blue"
+                onClick={() => setPlayerType('goaltenders')}
+              >
+                Goalies
+              </Button>
+            </ButtonGroup>
           </div>
 
           <div className="m-2 flex flex-col gap-4 md:flex-row md:justify-between">
@@ -501,7 +523,7 @@ export default () => {
               onChange={(event) => parseSearchQuery(event.target.value)}
             />
             <p className="mt-1 text-xs text-gray-400">
-              Search by player name, or use tags:{' '}
+              Search by player name, or user tags:{' '}
               <span className="font-mono">name:Andrei</span>{' '}
               <span className="font-mono">author:Enigmatic</span>{' '}
               <span className="font-mono">id:2528</span>

--- a/pages/packs/last-pack/index.tsx
+++ b/pages/packs/last-pack/index.tsx
@@ -145,7 +145,7 @@ const LastOpenedPack = () => {
     { id: rarityMap.ruby.label, color: HexCodes.Ruby, emoji: '🔴' },
     { id: rarityMap.diamond.label, color: HexCodes.Diamond, emoji: '💎' },
     { id: rarityMap.hallOfFame.label, color: HexCodes.Gold, emoji: '🐐' },
-    { id: rarityMap.draftNight.label, color: HexCodes.Gold, emoji: '🎯' },
+    { id: rarityMap.draftNight.label, emoji: '🎯' },
     { id: rarityMap.twoThousandClub.label, color: HexCodes.Gold, emoji: '🎉' },
     { id: rarityMap.award.label, color: HexCodes.Award, emoji: '🏆' },
     { id: rarityMap.firstOverall.label, color: HexCodes.Gold, emoji: '☝️' },


### PR DESCRIPTION
Delete the color hue of draft night
Added switches to Forward / Goalie again (just this time nicer). because when you go to your claimed cards it only has skaters For the render info for draft night, need to default the leagueID to 1