### PR TITLE
Feat/qol fixes

### DIFF
--- a/components/collection/CardInformation.tsx
+++ b/components/collection/CardInformation.tsx
@@ -209,6 +209,11 @@ export const CardInformation = ({
                     borderWidth="1px"
                     rounded="md"
                     mb={2}
+                    className={
+                      session?.userId == String(pack.userID)
+                        ? 'shadow-[0_0_25px_rgba(59,130,246,1)]'
+                        : ''
+                    }
                   >
                     <div>
                       {pack.username} : {pack.total}

--- a/components/collection/DisplayPacks.tsx
+++ b/components/collection/DisplayPacks.tsx
@@ -1,14 +1,17 @@
 import {
-  Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  AccordionIcon,
   Image,
-  Box,
   SimpleGrid,
   Spinner,
   Button,
+  Drawer,
+  DrawerBody,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  DrawerHeader,
+  useDisclosure,
+  IconButton,
+  Flex,
 } from '@chakra-ui/react'
 import React, { useState, useMemo, useCallback } from 'react'
 import axios from 'axios'
@@ -18,6 +21,7 @@ import PackOpen from '@components/collection/PackOpen'
 import { UserPacks } from '@pages/api/v3'
 import { useRouter } from 'next/router'
 import { packService } from 'services/packService'
+import { ArrowBackIcon } from '@chakra-ui/icons'
 
 interface DisplayPacksProps {
   userID: string
@@ -25,25 +29,31 @@ interface DisplayPacksProps {
 
 const DisplayPacks: React.FC<DisplayPacksProps> = React.memo(({ userID }) => {
   const router = useRouter()
+  const { isOpen, onOpen, onClose } = useDisclosure()
   const [selectedPackID, setSelectedPackID] = useState<string | null>(null)
-  const [isPanelOpen, setIsPanelOpen] = useState(false)
 
   const { payload: packs, isLoading: packsLoading } = query<UserPacks[]>({
     queryKey: ['latest-cards', userID],
     queryFn: () =>
       axios({
         method: GET,
-        url: `/api/v3/collection/uid/latest-packs?userID=${userID}`,
+        url: `/api/v3/collection/uid/latest-packs?userID=${userID}&limit=20`,
       }),
-    enabled: !!userID && isPanelOpen,
+    enabled: !!userID && isOpen,
   })
 
-  const handlePackClick = useCallback(
-    (packID: string) => {
-      setSelectedPackID(packID === selectedPackID ? null : packID)
-    },
-    [selectedPackID]
-  )
+  const openPackView = useCallback((packID: string) => {
+    setSelectedPackID(packID)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    onClose()
+    setSelectedPackID(null)
+  }, [onClose])
+
+  const handleBack = useCallback(() => {
+    setSelectedPackID(null)
+  }, [])
 
   const packImages = useMemo(
     () =>
@@ -56,64 +66,91 @@ const DisplayPacks: React.FC<DisplayPacksProps> = React.memo(({ userID }) => {
   )
 
   return (
-    <Accordion allowToggle>
-      <AccordionItem>
-        <h2>
-          <AccordionButton onClick={() => setIsPanelOpen((prev) => !prev)}>
-            <Box flex="1" textAlign="left" fontWeight="bold" fontSize="lg">
-              Latest Packs Opened
-            </Box>
-            <AccordionIcon />
-          </AccordionButton>
-        </h2>
-        <AccordionPanel pb={4}>
-          {isPanelOpen && (
-            <>
-              {packsLoading ? (
-                <Spinner />
-              ) : packs && packs.length > 0 ? (
-                <SimpleGrid columns={3} spacing={4}>
-                  {packImages.map((imageSrc, index) => (
-                    <Box key={packs[index].packID} textAlign="center">
-                      <Image
-                        src={imageSrc}
-                        alt={`Pack Cover ${index + 1}`}
-                        onClick={() => handlePackClick(packs[index].packID)}
-                        className="cursor-pointer"
-                        width={100}
-                        height={175}
-                        style={{
-                          border:
-                            selectedPackID === packs[index].packID
-                              ? '2px solid yellow'
-                              : 'none',
-                        }}
-                      />
-                    </Box>
-                  ))}
-                </SimpleGrid>
-              ) : (
-                <div>No packs available.</div>
-              )}
+    <>
+      <Button
+        onClick={onOpen}
+        colorScheme="teal"
+        className="w-full !text-sm sm:!text-lg  sm:w-auto"
+      >
+        View Latest Packs
+      </Button>
+
+      <Drawer isOpen={isOpen} placement="right" onClose={handleClose} size="lg">
+        <DrawerOverlay />
+        <DrawerContent className="!bg-primary !text-primary">
+          <DrawerCloseButton />
+          <DrawerHeader className="border-b border-gray-600">
+            <Flex align="center" gap={2}>
               {selectedPackID && (
-                <>
-                  <Button
-                    mt={4}
-                    colorScheme="green"
-                    onClick={() => router.push(`/packs/${selectedPackID}`)}
-                  >
-                    Go to pack
-                  </Button>
-                  <Box mt={4}>
-                    <PackOpen packID={selectedPackID} />
-                  </Box>
-                </>
+                <IconButton
+                  aria-label="Back to packs"
+                  icon={<ArrowBackIcon />}
+                  size="sm"
+                  className="!bg-primary !text-primary hover:!bg-secondary"
+                  onClick={handleBack}
+                />
               )}
-            </>
-          )}
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
+              {selectedPackID ? 'Pack Details' : 'Your 20 Latest Packs'}
+            </Flex>
+          </DrawerHeader>
+          <DrawerBody>
+            {selectedPackID ? (
+              <>
+                <div className="mb-3">
+                  <Button
+                    size="sm"
+                    colorScheme="blue"
+                    onClick={() => router.push(`/packs/${selectedPackID}`)}
+                    width="full"
+                  >
+                    View Full Page
+                  </Button>
+                </div>
+                <PackOpen packID={selectedPackID} viewCard={false} />
+              </>
+            ) : (
+              <>
+                {packsLoading ? (
+                  <Spinner />
+                ) : packs && packs.length > 0 ? (
+                  <SimpleGrid columns={2} spacing={4}>
+                    {packs.map((pack, index) => (
+                      <div
+                        key={pack.packID}
+                        onClick={() => openPackView(pack.packID)}
+                        className="
+                          cursor-pointer
+                          border border-white
+                          rounded-md p-3
+                          transition-all duration-200 ease-in-out
+                          hover:scale-105 hover:border-blue700 hover:shadow-lg
+                          active:scale-100
+                        "
+                      >
+                        <Image src={packImages[index]} alt="Pack" mb={2} />
+
+                        <div className="space-y-1">
+                          <p className="text-sm">
+                            Opened:{' '}
+                            {new Date(pack.openDate).toLocaleDateString()}
+                          </p>
+                          <p className="text-sm">
+                            Purchased:{' '}
+                            {new Date(pack.purchaseDate).toLocaleDateString()}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </SimpleGrid>
+                ) : (
+                  <div>No packs available.</div>
+                )}
+              </>
+            )}
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
   )
 })
 

--- a/components/collection/PackOpen.tsx
+++ b/components/collection/PackOpen.tsx
@@ -12,16 +12,13 @@ import { useState } from 'react'
 
 interface PackOpenProps {
   packID: string
+  viewCard?: boolean
 }
 
-const PackOpen: React.FC<PackOpenProps> = ({ packID }) => {
+const PackOpen: React.FC<PackOpenProps> = ({ packID, viewCard = true }) => {
   const [uid] = useCookie(config.userIDCookieName)
   const [lightBoxIsOpen, setLightBoxIsOpen] = useState<boolean>(false)
   const [selectedCard, setSelectedCard] = useState<LatestCards | null>(null)
-
-  const customLoader = (src: string) => {
-    return `https://simulationhockey.com/tradingcards/${src}.png`
-  }
 
   const { payload: cards, isLoading: isLoading } = query<LatestCards[]>({
     queryKey: ['latest-cards', packID],
@@ -67,7 +64,7 @@ const PackOpen: React.FC<PackOpenProps> = ({ packID }) => {
           </Box>
         ))}
       </SimpleGrid>
-      {lightBoxIsOpen && selectedCard && (
+      {lightBoxIsOpen && selectedCard && viewCard && (
         <CardLightBoxModal
           cardName={selectedCard.playerName}
           cardImage={selectedCard.imageURL}

--- a/pages/api/v3/collection/uid/latest-packs.ts
+++ b/pages/api/v3/collection/uid/latest-packs.ts
@@ -48,8 +48,8 @@ const handler = async (
 
     query.append(SQL` ORDER BY openDate DESC`)
 
-    if (userID && !packID) {
-      query.append(SQL` LIMIT ${limit ? parseInt(limit) : 3}`)
+    if (userID && !packID && limit) {
+      query.append(SQL` LIMIT ${parseInt(limit)}`)
     }
 
     const queryResult = await cardsQuery<UserPacks>(query)

--- a/pages/api/v3/collection/uid/latest-packs.ts
+++ b/pages/api/v3/collection/uid/latest-packs.ts
@@ -23,6 +23,7 @@ const handler = async (
   if (req.method === GET) {
     const userID = req.query.userID as string
     const packID = req.query.packID as string
+    const limit = req.query.limit as string
 
     if (!userID && !packID) {
       res
@@ -48,7 +49,7 @@ const handler = async (
     query.append(SQL` ORDER BY openDate DESC`)
 
     if (userID && !packID) {
-      query.append(SQL` LIMIT 3`)
+      query.append(SQL` LIMIT ${limit ? parseInt(limit) : 3}`)
     }
 
     const queryResult = await cardsQuery<UserPacks>(query)
@@ -62,12 +63,10 @@ const handler = async (
     }
 
     if (queryResult.length === 0) {
-      res
-        .status(StatusCodes.NOT_FOUND)
-        .json({
-          status: 'error',
-          message: 'No opened packs found for this user',
-        })
+      res.status(StatusCodes.NOT_FOUND).json({
+        status: 'error',
+        message: 'No opened packs found for this user',
+      })
       return
     }
 

--- a/pages/api/v3/index.d.ts
+++ b/pages/api/v3/index.d.ts
@@ -65,8 +65,7 @@ export type UserPacks = {
   opened: number
   purchaseDate: string
   openDate: string
-  source
-  string
+  source: string
 }
 
 export type Rarities = {

--- a/pages/collect/[uid].tsx
+++ b/pages/collect/[uid].tsx
@@ -287,7 +287,10 @@ export default ({ uid }: { uid: string }) => {
         {userIsLoading ? (
           <Spinner />
         ) : (
-          <div>{pluralizeName(user?.username)}&nbsp;Collection</div>
+          <div>
+            {pluralizeName(user?.username)}&nbsp;Collection: {totalOwnedCards}{' '}
+            Cards Owned
+          </div>
         )}
       </div>
       <div className="mb-3" />

--- a/pages/collect/[uid].tsx
+++ b/pages/collect/[uid].tsx
@@ -129,7 +129,7 @@ export default ({ uid }: { uid: string }) => {
   const [sortDirection, setSortDirection] = useState<SortDirection>('DESC')
   const [tablePage, setTablePage] = useState<number>(1)
   const [otherUID, setOtherUID] = useState<string>('')
-  const [leagueID, setLeagueID] = useState<string[]>(['0'])
+  const [leagueID, setLeagueID] = useState<string[]>(['0', '1', '2'])
   const [debouncedPlayerName] = useDebounce(playerName, 500)
 
   const [loggedInUID] = useCookie(config.userIDCookieName)
@@ -284,21 +284,31 @@ export default ({ uid }: { uid: string }) => {
   return (
     <PageWrapper>
       <div className="border-b-8 border-b-blue700 bg-secondary p-4 text-lg font-bold text-secondaryText sm:text-xl">
-        {userIsLoading ? (
-          <Spinner />
-        ) : (
-          <div>
-            {pluralizeName(user?.username)}&nbsp;Collection: {totalOwnedCards}{' '}
-            Cards Owned
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
+            {userIsLoading ? (
+              <Spinner />
+            ) : (
+              <div className="truncate">
+                {pluralizeName(user?.username)}&nbsp;Collection:{' '}
+                {totalOwnedCards > 0 ? totalOwnedCards : 0} Cards Owned
+              </div>
+            )}
           </div>
-        )}
+
+          <div className="flex-shrink-0">
+            {payload && payload.totalOwned !== null && (
+              <div className="w-full sm:w-auto">
+                <DisplayPacks userID={uid} />
+              </div>
+            )}
+          </div>
+        </div>
       </div>
       <div className="mb-3" />
       {payload && payload.totalOwned !== null && (
         <DisplayCollection uid={uid} />
       )}
-      <div className="mb-3" />
-      {payload && payload.totalOwned !== null && <DisplayPacks userID={uid} />}
       <div className="mb-3" />
 
       <div className="border-b-8 border-b-blue700 bg-secondary p-4 text-lg font-bold text-secondaryText sm:text-xl mb-6">

--- a/pages/packs/last-pack/index.tsx
+++ b/pages/packs/last-pack/index.tsx
@@ -16,6 +16,13 @@ import {
   BreadcrumbLink,
   Breadcrumb,
   Spinner,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
 } from '@chakra-ui/react'
 import { PageWrapper } from '@components/common/PageWrapper'
 import { GET } from '@constants/http-methods'
@@ -56,6 +63,7 @@ const LastOpenedPack = () => {
   const [loggedInUID] = useCookie(config.userIDCookieName)
   const queryClient = useQueryClient()
   const { type } = router.query as { type: string }
+  const [showUnflippedModal, setShowUnflippedModal] = useState(false)
 
   useEffect(() => {
     if (!loggedIn) {
@@ -93,26 +101,6 @@ const LastOpenedPack = () => {
     isError: useOpenPackIsError,
   } = useOpenPack()
 
-  const OpenNextPack = (pack: UserPacks) => {
-    if (useOpenPackIsLoading) {
-      toast({
-        title: 'Already opening a pack',
-        description: `Bro chill we're still opening that pack`,
-        ...warningToastOptions,
-      })
-      return
-    }
-    if (!pack) {
-      toast({
-        title: 'No Packs Available',
-        description: `You don't have any ${type} packs to open.`,
-        ...errorToastOptions,
-      })
-      return
-    }
-    openPack({ packID: pack.packID })
-  }
-
   const { payload: user } = query<UserData>({
     queryKey: ['baseUser', session?.token],
     queryFn: () =>
@@ -135,6 +123,38 @@ const LastOpenedPack = () => {
     } else {
       updateRevealedCards(index)
     }
+  }
+  const OpenNextPack = (pack: UserPacks) => {
+    if (useOpenPackIsLoading) {
+      toast({
+        title: 'Already opening a pack',
+        description: `Bro chill we're still opening that pack`,
+        ...warningToastOptions,
+      })
+      return
+    }
+
+    if (revealedCards.length < latestPackCards.length) {
+      setShowUnflippedModal(true)
+      return
+    }
+
+    if (!pack) {
+      toast({
+        title: 'No Packs Available',
+        description: `You don't have any ${type} packs to open.`,
+        ...errorToastOptions,
+      })
+      return
+    }
+    openPack({ packID: pack.packID })
+  }
+
+  const confirmOpenNextPack = () => {
+    if (!firstPack) return
+
+    setShowUnflippedModal(false)
+    openPack({ packID: firstPack.packID })
   }
 
   const cardRarityShadows = [
@@ -387,6 +407,37 @@ const LastOpenedPack = () => {
           </div>
         </div>
       </div>
+      <Modal
+        isOpen={showUnflippedModal}
+        onClose={() => setShowUnflippedModal(false)}
+        isCentered
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader className="text-primary bg-primary">
+            Unflipped Cards Remaining
+          </ModalHeader>
+          <ModalCloseButton />
+
+          <ModalBody className="text-primary bg-primary">
+            You still have cards in this pack that have not been revealed. Are
+            you sure you want to open the next pack?
+          </ModalBody>
+
+          <ModalFooter className="text-primary bg-primary">
+            <Button
+              onClick={() => setShowUnflippedModal(false)}
+              mr={3}
+              colorScheme="red"
+            >
+              Cancel
+            </Button>
+            <Button colorScheme="green" onClick={confirmOpenNextPack}>
+              Open Next Pack
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </PageWrapper>
   )
 }

--- a/pages/packs/last-pack/index.tsx
+++ b/pages/packs/last-pack/index.tsx
@@ -44,6 +44,7 @@ import useOpenPack from '@pages/api/mutations/use-open-pack'
 import { ChevronLeftIcon } from '@chakra-ui/icons'
 import Image from 'next/image'
 import { useQueryClient } from 'react-query'
+import DisplayPacks from '@components/collection/DisplayPacks'
 
 const HexCodes = {
   Ruby: '#E0115F',
@@ -251,9 +252,14 @@ const LastOpenedPack = () => {
         <NextSeo title="Last Pack" />
         <div className="flex items-center space-x-2">
           <Breadcrumb>
-            <ChevronLeftIcon color="gray.500" />
             <BreadcrumbItem>
-              <BreadcrumbLink href="/packs">Return to Packs</BreadcrumbLink>
+              <BreadcrumbLink
+                href="/packs"
+                className="inline-flex items-center gap-1 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm hover:bg-white/10"
+              >
+                <ChevronLeftIcon />
+                Return to Packs
+              </BreadcrumbLink>
             </BreadcrumbItem>
           </Breadcrumb>
 
@@ -267,14 +273,14 @@ const LastOpenedPack = () => {
             </Badge>
           )}
         </div>
-        <div className="flex flex-row items-center justify-start space-x-2 pt-3">
+        <div className="w-full pt-3 grid grid-cols-2 gap-2 sm:flex sm:flex-row sm:flex-wrap sm:items-center sm:justify-start sm:gap-2">
           {firstPack ? (
             <Tooltip label="Open a new pack">
               <Button
                 isDisabled={useOpenPackIsLoading || packsLoading}
                 onClick={() => OpenNextPack(firstPack)}
                 position="relative"
-                className="!text-xs sm:!text-lg"
+                className="w-full sm:w-auto !text-sm sm:!text-lg !px-3 sm:!px-6 !py-2 sm:!py-4"
               >
                 {(useOpenPackIsLoading || packsLoading) && (
                   <Spinner size="sm" mr={2} />
@@ -283,24 +289,32 @@ const LastOpenedPack = () => {
               </Button>
             </Tooltip>
           ) : (
-            <Button className="!text-xs sm:!text-lg" isDisabled>
+            <Button
+              isDisabled
+              className="w-full sm:w-auto !text-sm sm:!text-lg !px-3 sm:!px-6 !py-2 sm:!py-4"
+            >
               No More {type} Packs to Open
             </Button>
           )}
+
           <Button
-            className="!text-xs sm:!text-base"
-            disabled={false}
             onClick={flipAllCards}
+            className="w-full sm:w-auto !text-sm sm:!text-lg !px-3 sm:!px-6 !py-2 sm:!py-4"
           >
             Flip All Cards
           </Button>
+
           <Button
-            className="!text-lg"
             onClick={shareMessage}
             colorScheme="teal"
+            className="w-full sm:w-auto !text-sm sm:!text-lg !px-3 sm:!px-5 !py-2 sm:!py-4"
           >
             Share
           </Button>
+
+          <div className="w-full sm:w-auto">
+            <DisplayPacks userID={session.userId} />
+          </div>
         </div>
 
         <div className="m-2" style={{ height: 'calc(100vh-64px)' }}>


### PR DESCRIPTION
- Added a pop up modal if the user clicks open another pack but still have cards that arent flipped. So that they dont fat finger the button
- Changed the latest packs to be a drawer. Changed the amount from 3 to 20. Allows me to put the view latest in the lateset cards page as well. So that the user doesnt have to move off of the latest cards page to view their past packs
- Changed default league selection to all instead of SHL
- At the top of your collection next to name displays the number of cards you own (instead of looking when you click show unowned). Updates with the filters
- When you see the number of cards owned by each user, if youre logged in then your name has a shadow to it

<img width="1556" height="782" alt="image" src="https://github.com/user-attachments/assets/eb450964-5858-486f-b3f3-6692c8b20d8e" />
<img width="1755" height="928" alt="image" src="https://github.com/user-attachments/assets/e2cc1a23-47ad-4d33-adf7-3171925c7ad7" />
<img width="1787" height="903" alt="image" src="https://github.com/user-attachments/assets/f32dbdbc-215d-4504-ab52-4f5bb91819b5" />
<img width="1434" height="745" alt="image" src="https://github.com/user-attachments/assets/d0e76bc6-14c3-4aaf-9333-e25a03f2bef5" />
