### PR TITLE
Reimagining the collections area

### DIFF
--- a/components/collection/DisplayCollection.tsx
+++ b/components/collection/DisplayCollection.tsx
@@ -133,7 +133,7 @@ const DisplayCollection = ({ uid, onShowMissing }: DisplayCollectionProps) => {
       <div className="p-4 bg-secondary">
         <div className="mb-5">
           <div className="font-bold text-3xl">Collection overview</div>
-          <div className="text-sm">Updates every 12 hours</div>
+          <div className="text-sm">Updated at 12PM, 6PM, 12AM, 6AM EST</div>
         </div>
 
         {selected ? (

--- a/components/collection/DisplayCollection.tsx
+++ b/components/collection/DisplayCollection.tsx
@@ -1,118 +1,264 @@
-import {
-  Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  AccordionIcon,
-  Box,
-  Skeleton,
-  VStack,
-  Wrap,
-  WrapItem,
-  Progress,
-} from '@chakra-ui/react'
-import { Fragment, useState } from 'react'
-import { SiteUniqueCards, UserUniqueCollection } from '@pages/api/v3'
-import { query } from '@pages/api/database/query'
+import { Badge, Progress, Skeleton } from '@chakra-ui/react'
+import { Fragment, useMemo, useState } from 'react'
 import axios from 'axios'
 import { GET } from '@constants/http-methods'
+import { query } from '@pages/api/database/query'
+import { DEFAULT_RARITY, RARITY_CONFIG } from '@utils/marketplace-rarity-maps'
+import SubRarityCollection from './SubRarityCollection'
+import { SiteGroupedUniqueCards, UserCollection } from '@pages/api/v3'
+import { rarityMap } from '@constants/rarity-map'
 
 interface DisplayCollectionProps {
   uid: string
+  onShowMissing: (rarity: string, subType?: string) => void
 }
 
-const DisplayCollection = ({ uid }: DisplayCollectionProps) => {
-  const [isPanelOpen, setIsPanelOpen] = useState(false)
+const DisplayCollection = ({ uid, onShowMissing }: DisplayCollectionProps) => {
+  const [selected, setSelected] = useState<UserCollection | null>(null)
 
-  const { payload: userUniqueCards, isLoading: userUniqueCardsIsLoading } =
-    query<UserUniqueCollection[]>({
-      queryKey: ['user-unique-cards', uid],
-      queryFn: () =>
-        axios({
-          method: GET,
-          url: `/api/v3/collection/collection-by-rarity?userID=${uid}`,
-        }),
-      enabled: isPanelOpen,
+  const { payload: siteCards, isLoading: siteLoading } = query<
+    SiteGroupedUniqueCards[]
+  >({
+    queryKey: ['unique-cards'],
+    queryFn: () =>
+      axios({
+        method: GET,
+        url: `/api/v3/collection/unique-cards`,
+      }),
+  })
+
+  const { payload: userCards, isLoading: userLoading } = query<
+    UserCollection[]
+  >({
+    queryKey: ['user-unique-cards', uid],
+    queryFn: () =>
+      axios({
+        method: GET,
+        url: `/api/v3/collection/collection-by-rarity?userID=${uid}`,
+      }),
+  })
+
+  const combinedView = useMemo(() => {
+    if (!siteCards || !userCards) return []
+
+    const userMap = new Map<string, UserCollection>()
+    for (const u of userCards) {
+      userMap.set(u.card_rarity, u)
+    }
+
+    const result = siteCards.map((site) => {
+      const user = userMap.get(site.card_rarity)
+
+      const userSubMap = new Map<string, any>()
+      for (const s of user?.subTypes ?? []) {
+        userSubMap.set(s.sub_type, s)
+      }
+
+      const subTypes = site.subTypes.map((siteSub) => {
+        const userSub = userSubMap.get(siteSub.sub_type)
+
+        return {
+          sub_type: siteSub.sub_type,
+          owned_count: userSub?.owned_count,
+          rarity_rank: userSub?.rarity_rank,
+          total_count: siteSub.total_count ?? 0,
+        }
+      })
+
+      return {
+        card_rarity: site.card_rarity,
+        owned_count: user?.owned_count ?? 0,
+        userID: user?.userID ?? 0,
+        username: user?.username ?? '',
+        rarity_rank: user?.rarity_rank ?? 0,
+        total_count: site.total_count,
+        subTypes,
+      }
     })
 
-  const { payload: siteUniqueCards, isLoading: siteUniqueCardsIsLoading } =
-    query<SiteUniqueCards[]>({
-      queryKey: ['unique-cards'],
-      queryFn: () =>
-        axios({
-          method: GET,
-          url: `/api/v3/collection/unique-cards`,
-        }),
-      enabled: isPanelOpen,
-    })
-
-  const getUserOwnedCount = (rarity: string) => {
-    const userCard = userUniqueCards?.find(
-      (card) => card.card_rarity === rarity
+    const rarityByLabel = Object.values(rarityMap).reduce(
+      (acc, r) => {
+        acc[r.label.toLowerCase()] = r.rarity
+        return acc
+      },
+      {} as Record<string, number>
     )
-    return userCard
-      ? { owned_count: userCard.owned_count, rarity_rank: userCard.rarity_rank }
-      : { owned_count: 0, rarity_rank: 0 }
+
+    return result.sort((a, b) => {
+      const aRarity = rarityByLabel[a.card_rarity.toLowerCase()] ?? -1
+      const bRarity = rarityByLabel[b.card_rarity.toLowerCase()] ?? -1
+      return bRarity - aRarity
+    })
+  }, [siteCards, userCards])
+
+  const userStats = useMemo(() => {
+    if (!combinedView.length) return null
+
+    return {
+      totalOwned: combinedView.reduce((s, r) => s + r.owned_count, 0),
+      completedSets: combinedView.filter((r) => r.owned_count === r.total_count)
+        .length,
+      completedSubSets: combinedView.reduce((acc, r) => {
+        return (
+          acc +
+          r.subTypes.filter(
+            (s) => s.owned_count > 0 && s.owned_count === s.total_count
+          ).length
+        )
+      }, 0),
+      top10Ranks: combinedView.filter(
+        (r) => r.rarity_rank > 0 && r.rarity_rank <= 10
+      ).length,
+      bestRank:
+        combinedView.length > 0
+          ? Math.min(
+              ...combinedView.map((r) => r.rarity_rank).filter((r) => r > 0)
+            )
+          : null,
+    }
+  }, [combinedView])
+
+  if (siteLoading || userLoading) {
+    return (
+      <div className="p-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} height="80px" mb={3} />
+        ))}
+      </div>
+    )
   }
 
   return (
-    <Accordion allowToggle>
-      <AccordionItem>
-        <h2>
-          <AccordionButton onClick={() => setIsPanelOpen(!isPanelOpen)}>
-            <Box flex="2" textAlign="left" fontWeight="bold" fontSize="lg">
-              Collection Sets
-            </Box>
-            <AccordionIcon />
-          </AccordionButton>
-        </h2>
-        <AccordionPanel pb={4}>
-          {isPanelOpen && (
-            <>
-              {siteUniqueCardsIsLoading || userUniqueCardsIsLoading ? (
-                <Skeleton height="40px" width="100%" />
-              ) : userUniqueCardsIsLoading ? (
-                <VStack>
-                  {Array.from({ length: 6 }).map((_, index) => (
-                    <Skeleton key={index} height="40px" width="100%" />
-                  ))}
-                </VStack>
-              ) : (
-                <Fragment>
-                  <Wrap spacing={4} mt={2}>
-                    {siteUniqueCards.map((siteCard) => {
-                      const { owned_count, rarity_rank } = getUserOwnedCount(
-                        siteCard.card_rarity
-                      )
-                      const totalCount = siteCard.total_count
-                      const progressValue = (owned_count / totalCount) * 100
-                      const isComplete = owned_count === totalCount
+    <div className="border border-grey800 rounded-lg overflow-hidden">
+      <div className="p-4 bg-secondary">
+        <div className="mb-5">
+          <div className="font-bold text-3xl">Collection overview</div>
+          <div className="text-sm">Updates every 12 hours</div>
+        </div>
 
-                      return (
-                        <WrapItem key={siteCard.card_rarity} width="100%">
-                          <Box width="100%">
-                            <div className="font-bold mb-1">
-                              {siteCard.card_rarity}: {owned_count} /{' '}
-                              {totalCount} [ #{rarity_rank} Global]
-                            </div>
-                            <Progress
-                              value={progressValue}
-                              colorScheme={isComplete ? 'green' : 'blue'}
-                              borderRadius="md"
-                              hasStripe
-                            />
-                          </Box>
-                        </WrapItem>
-                      )
-                    })}
-                  </Wrap>
-                </Fragment>
-              )}
-            </>
-          )}
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
+        {selected ? (
+          <SubRarityCollection
+            rarity={selected}
+            onBack={() => setSelected(null)}
+            onShowMissing={onShowMissing}
+          />
+        ) : (
+          <Fragment>
+            {userStats && (
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
+                {[
+                  { label: 'Total cards', value: userStats.totalOwned },
+                  {
+                    label: 'Sets completed',
+                    value: userStats.completedSets,
+                  },
+                  {
+                    label: 'Sub Sets completed',
+                    value: userStats.completedSubSets,
+                  },
+                  { label: 'Top-10 ranks', value: userStats.top10Ranks },
+                  {
+                    label: 'Best rank',
+                    value: userStats.bestRank ? `#${userStats.bestRank}` : '—',
+                  },
+                ].map((s) => (
+                  <div
+                    key={s.label}
+                    className="bg-primary rounded-lg px-3 py-2"
+                  >
+                    <div className="text-xs text-secondaryText mb-1">
+                      {s.label}
+                    </div>
+                    <div className="text-2xl font-bold">{s.value}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              {combinedView.map((rarity) => {
+                const cfg = RARITY_CONFIG[rarity.card_rarity] ?? DEFAULT_RARITY
+
+                const pct =
+                  rarity.total_count > 0
+                    ? (rarity.owned_count / rarity.total_count) * 100
+                    : 0
+
+                const isComplete = rarity.owned_count === rarity.total_count
+
+                const hasSubTypes = rarity.subTypes.length > 0
+
+                return (
+                  <div
+                    key={rarity.card_rarity}
+                    role={hasSubTypes ? 'button' : undefined}
+                    tabIndex={hasSubTypes ? 0 : undefined}
+                    aria-label={
+                      hasSubTypes
+                        ? `View ${rarity.card_rarity} sub-types`
+                        : undefined
+                    }
+                    className="rounded-lg p-4 transition-colors border-l-4 bg-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+                    style={{
+                      borderColor: isComplete ? '#22c55e' : `${cfg.accent}`,
+                      cursor: hasSubTypes ? 'pointer' : 'default',
+                    }}
+                    onClick={() => hasSubTypes && setSelected(rarity)}
+                    onKeyDown={(e) => {
+                      if (hasSubTypes && (e.key === 'Enter' || e.key === ' ')) {
+                        e.preventDefault()
+                        setSelected(rarity)
+                      }
+                    }}
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <span className="font-bold uppercase tracking-wider">
+                        {rarity.card_rarity}
+                      </span>
+
+                      <Badge>#{rarity.rarity_rank} Global</Badge>
+                    </div>
+
+                    <div className="text-3xl font-bold">
+                      {rarity.owned_count}
+                    </div>
+
+                    <div className="flex items-center justify-between text-xs text-secondaryText mb-2">
+                      <span>of {rarity.total_count}</span>
+                      {!isComplete && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onShowMissing(rarity.card_rarity)
+                          }}
+                          className="text-blue600 hover:underline"
+                        >
+                          Show missing →
+                        </button>
+                      )}
+                    </div>
+
+                    <Progress value={pct} size="xs" />
+
+                    {isComplete && (
+                      <div className="text-xs mt-2 text-green-400 font-bold">
+                        ✓ Complete
+                      </div>
+                    )}
+
+                    {hasSubTypes && (
+                      <div className="text-xs mt-2 text-secondaryText">
+                        {rarity.subTypes.length} sub-types ›
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </Fragment>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/components/collection/DisplayCollection.tsx
+++ b/components/collection/DisplayCollection.tsx
@@ -216,7 +216,11 @@ const DisplayCollection = ({ uid, onShowMissing }: DisplayCollectionProps) => {
                         {rarity.card_rarity}
                       </span>
 
-                      <Badge>#{rarity.rarity_rank} Global</Badge>
+                      <Badge>
+                        {rarity.rarity_rank > 0
+                          ? `#${rarity.rarity_rank} Global`
+                          : 'Unranked'}
+                      </Badge>
                     </div>
 
                     <div className="text-3xl font-bold">
@@ -246,7 +250,7 @@ const DisplayCollection = ({ uid, onShowMissing }: DisplayCollectionProps) => {
                       </div>
                     )}
 
-                    {hasSubTypes && (
+                    {hasSubTypes && rarity.card_rarity != 'Misprint' && (
                       <div className="text-xs mt-2 text-secondaryText">
                         {rarity.subTypes.length} sub-types ›
                       </div>

--- a/components/collection/SubRarityCollection.tsx
+++ b/components/collection/SubRarityCollection.tsx
@@ -1,0 +1,134 @@
+import { Badge, Progress } from '@chakra-ui/react'
+import { UserCollection } from '@pages/api/v3'
+import { DEFAULT_RARITY, RARITY_CONFIG } from '@utils/marketplace-rarity-maps'
+
+type Props = {
+  rarity: UserCollection
+  onBack: () => void
+  onShowMissing: (rarity: string, subType?: string) => void
+}
+
+const SubRarityCollection = ({ rarity, onBack, onShowMissing }: Props) => {
+  const cfg = RARITY_CONFIG[rarity.card_rarity] ?? DEFAULT_RARITY
+
+  const pct =
+    rarity.total_count > 0 ? (rarity.owned_count / rarity.total_count) * 100 : 0
+
+  const isComplete =
+    rarity.owned_count === rarity.total_count && rarity.total_count > 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          aria-label="Back to collection overview"
+          className="text-sm font-semibold px-3 py-1.5 border rounded-md hover:bg-primary transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+        >
+          ← Back
+        </button>
+
+        <div className="flex items-center gap-2">
+          <span className="font-bold uppercase text-lg">
+            {rarity.card_rarity}
+          </span>
+
+          {isComplete && (
+            <span className="text-xs text-green-400 font-bold">✓ Complete</span>
+          )}
+        </div>
+
+        <Badge className="ml-auto">#{rarity.rarity_rank} Global</Badge>
+      </div>
+
+      <div
+        className="rounded-lg p-4 transition-colors border-l-4 bg-primary"
+        style={{
+          borderColor: isComplete ? '#22c55e' : `${cfg.accent}`,
+        }}
+      >
+        <div className="flex justify-between text-sm mb-1.5">
+          <span className="text-secondaryText">
+            {rarity.owned_count} / {rarity.total_count}
+          </span>
+
+          <span className="font-semibold">{Math.round(pct)}%</span>
+        </div>
+
+        <Progress
+          value={pct}
+          size="sm"
+          borderRadius="md"
+          sx={{
+            '& > div': {
+              background: isComplete ? '#22c55e' : cfg.accent,
+            },
+          }}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {rarity.subTypes.map((sub) => {
+          const subPct =
+            sub.owned_count > 0 ? (sub.owned_count / sub.total_count) * 100 : 0
+
+          const subComplete =
+            sub.owned_count === sub.total_count && sub.total_count > 0
+
+          return (
+            <div
+              key={sub.sub_type}
+              className="rounded-lg p-4 transition-colors border-l-4 bg-primary hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-white"
+              style={{ borderColor: subComplete ? '#22c55e' : cfg.accent }}
+            >
+              <div className="flex justify-between mb-2">
+                <span className="text-sm font-bold truncate">
+                  {sub.sub_type}
+                  {subComplete && (
+                    <span className="ml-1 text-green-400">✓</span>
+                  )}
+                </span>
+
+                <span className="text-xs text-secondaryText">
+                  {sub.rarity_rank > 0 ? `#${sub.rarity_rank}` : 'N/A'}
+                </span>
+              </div>
+
+              <div className="flex justify-between text-xs mb-1.5 text-secondaryText">
+                <span>
+                  {sub.owned_count > 0 ? sub.owned_count : 0} /{' '}
+                  {sub.total_count}
+                </span>
+
+                <span>{Math.round(subPct)}%</span>
+              </div>
+
+              <Progress
+                value={subPct}
+                size="xs"
+                borderRadius="md"
+                sx={{
+                  '& > div': {
+                    background: subComplete ? '#22c55e' : cfg.accent,
+                  },
+                }}
+              />
+              {!subComplete && (
+                <button
+                  onClick={() =>
+                    onShowMissing(rarity.card_rarity, sub.sub_type)
+                  }
+                  className="text-xs mt-2 text-blue600 hover:underline block"
+                >
+                  Show missing →
+                </button>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default SubRarityCollection

--- a/components/collection/SubRarityCollection.tsx
+++ b/components/collection/SubRarityCollection.tsx
@@ -1,5 +1,6 @@
 import { Badge, Progress } from '@chakra-ui/react'
 import { UserCollection } from '@pages/api/v3'
+import { formatSubType } from '@utils/helpers'
 import { DEFAULT_RARITY, RARITY_CONFIG } from '@utils/marketplace-rarity-maps'
 
 type Props = {
@@ -83,7 +84,7 @@ const SubRarityCollection = ({ rarity, onBack, onShowMissing }: Props) => {
             >
               <div className="flex justify-between mb-2">
                 <span className="text-sm font-bold truncate">
-                  {sub.sub_type}
+                  {formatSubType(sub.sub_type)}
                   {subComplete && (
                     <span className="ml-1 text-green-400">✓</span>
                   )}

--- a/pages/api/v3/collection/collection-by-rarity.ts
+++ b/pages/api/v3/collection/collection-by-rarity.ts
@@ -5,7 +5,7 @@ import { GET } from '@constants/http-methods'
 import SQL, { SQLStatement } from 'sql-template-strings'
 import { StatusCodes } from 'http-status-codes'
 import methodNotAllowed from '../lib/methodNotAllowed'
-import { ApiResponse, UserUniqueCollection } from '..'
+import { ApiResponse, UserCollection, UserUniqueCollection } from '..'
 import { cardsQuery } from '@pages/api/database/database'
 import { rateLimit } from 'lib/rateLimit'
 
@@ -21,25 +21,32 @@ const handler = async (
   await middleware(req, res, cors)
   const card_rarity = req.query.card_rarity as string
   const userID = req.query.userID as string
+  const sub_type = req.query.sub_type as string
+  const base_sets = req.query.base_sets as string
   if (req.method === GET) {
     const queryString: SQLStatement = SQL`
       SELECT 
-    uuc.userID,
+    uc.userID,
     ui.username,
-    uuc.card_rarity,
-    uuc.owned_count,
-    uuc.rarity_rank
+    uc.card_rarity,
+    uc.sub_type,
+    uc.owned_count,
+    uc.rarity_rank
 FROM
-    user_unique_cards uuc JOIN user_info ui ON uuc.userID = ui.uid WHERE 1 `
+    user_collections uc JOIN user_info ui ON uc.userID = ui.uid WHERE 1 `
     if (card_rarity) {
-      queryString.append(SQL` and uuc.card_rarity = ${card_rarity}`)
+      queryString.append(SQL` and uc.card_rarity = ${card_rarity}`)
     }
     if (userID) {
-      queryString.append(SQL` AND uuc.userID = ${userID}`)
+      queryString.append(SQL` AND uc.userID = ${userID}`)
     }
-    queryString.append(SQL`
-    
-    GROUP BY uuc.userID, ui.username, uuc.card_rarity `)
+    if (sub_type) {
+      queryString.append(SQL` AND uc.sub_type = ${sub_type}`)
+    }
+    if (base_sets) {
+      queryString.append(SQL` and sub_type = '' `)
+    }
+    queryString.append(SQL`order by uc.owned_count DESC`)
 
     const queryResult = await cardsQuery<UserUniqueCollection>(queryString)
     if ('error' in queryResult) {
@@ -57,9 +64,45 @@ FROM
       return
     }
 
+    const grouped = new Map<string, UserCollection>()
+
+    for (const row of queryResult) {
+      const key = `${row.userID}:${row.card_rarity}`
+
+      if (!grouped.has(key)) {
+        grouped.set(key, {
+          card_rarity: row.card_rarity,
+          userID: row.userID,
+          username: row.username,
+          owned_count: 0,
+          rarity_rank: 0,
+          subTypes: [],
+        })
+      }
+
+      const entry = grouped.get(key)!
+      const isBase =
+        !row.sub_type || row.sub_type === '' || row.sub_type === 'null'
+
+      if (isBase) {
+        entry.owned_count = row.owned_count
+        entry.rarity_rank = row.rarity_rank
+      } else {
+        entry.subTypes.push({
+          sub_type: row.sub_type,
+          owned_count: row.owned_count,
+          rarity_rank: row.rarity_rank,
+        })
+      }
+    }
+
+    const result = Array.from(grouped.values()).sort(
+      (a, b) => b.owned_count - a.owned_count
+    )
+
     res.status(StatusCodes.OK).json({
       status: 'success',
-      payload: queryResult,
+      payload: Array.from(result.values()),
     })
     return
   }

--- a/pages/api/v3/collection/unique-cards.ts
+++ b/pages/api/v3/collection/unique-cards.ts
@@ -29,7 +29,7 @@ const handler = async (
 
   const query = SQL`
     SELECT card_rarity, sub_type, total_count
-    FROM unique_cards_2
+    FROM unique_cards
   `
 
   if (card_rarity) {

--- a/pages/api/v3/collection/unique-cards.ts
+++ b/pages/api/v3/collection/unique-cards.ts
@@ -2,59 +2,86 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import middleware from '@pages/api/database/middleware'
 import Cors from 'cors'
 import { GET } from '@constants/http-methods'
-import SQL, { SQLStatement } from 'sql-template-strings'
+import SQL from 'sql-template-strings'
 import { StatusCodes } from 'http-status-codes'
 import methodNotAllowed from '../lib/methodNotAllowed'
-import { ApiResponse, SiteUniqueCards } from '..'
+import { ApiResponse, SiteGroupedUniqueCards, SiteUniqueCards } from '..'
 import { cardsQuery } from '@pages/api/database/database'
 import { rateLimit } from 'lib/rateLimit'
 
-const allowedMethods: string[] = [GET]
+const allowedMethods = [GET]
+
 const cors = Cors({
   methods: allowedMethods,
 })
 
 const handler = async (
   req: NextApiRequest,
-  res: NextApiResponse<ApiResponse<SiteUniqueCards[] | null>>
+  res: NextApiResponse<ApiResponse<SiteGroupedUniqueCards[] | null>>
 ) => {
   await middleware(req, res, cors)
 
-  if (req.method === GET) {
-    const card_rarity = req.query.card_rarity as string
-
-    const query: SQLStatement = SQL`
-      SELECT card_rarity, total_count
-      FROM unique_cards
-    `
-    if (card_rarity) {
-      query.append(SQL` WHERE card_rarity = ${card_rarity}`)
-    }
-
-    const queryResult = await cardsQuery<SiteUniqueCards>(query)
-
-    if ('error' in queryResult) {
-      console.error(queryResult.error)
-      res
-        .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .end('Database connection failed')
-      return
-    }
-
-    if (queryResult.length === 0) {
-      res
-        .status(StatusCodes.NOT_FOUND)
-        .json({ status: 'error', message: 'No unique cards found' })
-      return
-    }
-
-    res.status(StatusCodes.OK).json({
-      status: 'success',
-      payload: queryResult,
-    })
-    return
+  if (req.method !== GET) {
+    return methodNotAllowed(req, res, allowedMethods)
   }
 
-  methodNotAllowed(req, res, allowedMethods)
+  const card_rarity = req.query.card_rarity as string | undefined
+
+  const query = SQL`
+    SELECT card_rarity, sub_type, total_count
+    FROM unique_cards_2
+  `
+
+  if (card_rarity) {
+    query.append(SQL` WHERE card_rarity = ${card_rarity}`)
+  }
+
+  const rows = await cardsQuery<SiteUniqueCards>(query)
+
+  if ('error' in rows) {
+    console.error(rows.error)
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .end('Database connection failed')
+  }
+
+  if (!rows.length) {
+    return res.status(StatusCodes.NOT_FOUND).json({
+      status: 'error',
+      message: 'No unique cards found',
+    })
+  }
+  const map = new Map<string, SiteGroupedUniqueCards>()
+
+  for (const row of rows) {
+    const rarity = row.card_rarity
+    const isBase =
+      !row.sub_type || row.sub_type === '' || row.sub_type === 'null'
+
+    if (!map.has(rarity)) {
+      map.set(rarity, {
+        card_rarity: rarity,
+        total_count: 0,
+        subTypes: [],
+      })
+    }
+
+    const entry = map.get(rarity)!
+
+    if (isBase) {
+      entry.total_count = row.total_count
+    } else {
+      entry.subTypes.push({
+        sub_type: row.sub_type,
+        total_count: row.total_count,
+      })
+    }
+  }
+
+  return res.status(StatusCodes.OK).json({
+    status: 'success',
+    payload: Array.from(map.values()),
+  })
 }
+
 export default rateLimit(handler)

--- a/pages/api/v3/index.d.ts
+++ b/pages/api/v3/index.d.ts
@@ -39,23 +39,39 @@ export type UserUniqueCollection = {
   userID: number
   username: string
   card_rarity: string
+  sub_type: string
   owned_count: number
   rarity_rank: number
 }
 
 export type SiteUniqueCards = {
   card_rarity: string
+  sub_type: string
   total_count: number
 }
 
+export type SiteGroupedUniqueCards = {
+  card_rarity: string
+  total_count: number
+  subTypes: {
+    sub_type: string | null
+    total_count: number
+  }[]
+}
+
 export type UserCollection = {
-  ownedCardID: number
+  card_rarity: string
+  owned_count: number
   userID: number
-  username?: string
-  cardID: number
-  packID: number
-  imageURL?: number
-  total?: number
+  username: string
+  rarity_rank: number
+  total_count?: number
+  subTypes: {
+    sub_type: string
+    owned_count: number
+    rarity_rank: number
+    total_count?: number
+  }[]
 }
 
 export type UserPacks = {

--- a/pages/collect/[uid].tsx
+++ b/pages/collect/[uid].tsx
@@ -281,6 +281,18 @@ export default ({ uid }: { uid: string }) => {
     setSubType((currentValue) => toggleOnfilters(currentValue, subType))
   }
 
+  const handleShowMissing = (rarity: string, subType?: string) => {
+    setRarities([rarity])
+    if (subType) setSubType([subType])
+    setShowNotOwnedCards(true)
+    setSortColumn('quantity')
+    setSortDirection('ASC')
+    document
+      .querySelector('.accordion-toggle-icon')
+      ?.closest('button')
+      ?.scrollIntoView({ behavior: 'smooth' })
+  }
+
   return (
     <PageWrapper>
       <div className="border-b-8 border-b-blue700 bg-secondary p-4 text-lg font-bold text-secondaryText sm:text-xl">
@@ -290,8 +302,7 @@ export default ({ uid }: { uid: string }) => {
               <Spinner />
             ) : (
               <div className="truncate">
-                {pluralizeName(user?.username)}&nbsp;Collection:{' '}
-                {totalOwnedCards > 0 ? totalOwnedCards : 0} Cards Owned
+                {pluralizeName(user?.username)}&nbsp;Collection
               </div>
             )}
           </div>
@@ -307,7 +318,7 @@ export default ({ uid }: { uid: string }) => {
       </div>
       <div className="mb-3" />
       {payload && payload.totalOwned !== null && (
-        <DisplayCollection uid={uid} />
+        <DisplayCollection uid={uid} onShowMissing={handleShowMissing} />
       )}
       <div className="mb-3" />
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,0 +1,7 @@
+export const formatSubType = (subType: string) =>
+  subType
+    .replace(/_/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')


### PR DESCRIPTION
DB side: For collections by user it is now set up on a Trigger + Proc system with a new db table
Triggers every 6 hours, calls rebuild_user_collections which then feeds into user_collections

userID, card_rarity, sub_type, owned_count, rarity_rank

With that, updated the collection-by-rarity.ts and unique-cards.ts api routes to handle it. As well as making them into friendlier JSON

Now the collection page will automatically load the data with switching to a static table. Reimagined what it would look like with cards, and hopefully helping the user see visually where they are at. Added some top stats showing the total cards, the sets they completed, sub sets compelted, top-10 ranks, and what their best rank is

You are also able to click Show Missing and go down to the collections area, with the rarity, sub_rarity and order by least to most. Seeing what you need

Also able to see the sub-types as well and which ones you completed


<img width="1606" height="832" alt="image" src="https://github.com/user-attachments/assets/c41c9727-963d-4ada-a2f1-d47734bea270" />
<img width="1596" height="849" alt="image" src="https://github.com/user-attachments/assets/e57a5cb8-81f7-4b59-9c2e-7da432a63a0b" />
